### PR TITLE
Remove /src from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-src/
 typings/


### PR DESCRIPTION
Reason: SourceMap is pointing at /src which didn't exist in the package

Other CycleJS packages (e.g. `xstream-adapter` equivalent) also doesn't include /src in .npmignore.
